### PR TITLE
Add sendfd.NewClient() to xconnectns chain

### DIFF
--- a/pkg/networkservice/chains/xconnectns/server.go
+++ b/pkg/networkservice/chains/xconnectns/server.go
@@ -24,18 +24,9 @@ import (
 	"net/url"
 
 	"git.fd.io/govpp.git/api"
-
-	"github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanismtranslation"
-
-	"github.com/networkservicemesh/api/pkg/api/networkservice"
-
-	"github.com/networkservicemesh/sdk-vpp/pkg/networkservice/up"
-	"github.com/networkservicemesh/sdk-vpp/pkg/networkservice/xconnect/l2xconnect"
-
-	"github.com/networkservicemesh/sdk-vpp/pkg/networkservice/mechanisms/vxlan"
-
 	"google.golang.org/grpc"
 
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/client"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/endpoint"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/clienturl"
@@ -43,16 +34,19 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanisms"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanisms/recvfd"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanisms/sendfd"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanismtranslation"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/adapters"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/metadata"
 	"github.com/networkservicemesh/sdk/pkg/tools/addressof"
 	"github.com/networkservicemesh/sdk/pkg/tools/token"
-
-	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/metadata"
 
 	"github.com/networkservicemesh/sdk-vpp/pkg/networkservice/connectioncontextkernel"
 	"github.com/networkservicemesh/sdk-vpp/pkg/networkservice/mechanisms/kernel"
 	"github.com/networkservicemesh/sdk-vpp/pkg/networkservice/mechanisms/memif"
+	"github.com/networkservicemesh/sdk-vpp/pkg/networkservice/mechanisms/vxlan"
 	"github.com/networkservicemesh/sdk-vpp/pkg/networkservice/tag"
+	"github.com/networkservicemesh/sdk-vpp/pkg/networkservice/up"
+	"github.com/networkservicemesh/sdk-vpp/pkg/networkservice/xconnect/l2xconnect"
 )
 
 // Connection aggregates the api.Connection and api.ChannelProvider interfaces
@@ -91,6 +85,7 @@ func NewServer(ctx context.Context, name string, authzServer networkservice.Netw
 					kernel.NewClient(vppConn),
 					vxlan.NewClient(vppConn, tunnelIP),
 					recvfd.NewClient(),
+					sendfd.NewClient(),
 				)
 			},
 			clientDialOptions...,


### PR DESCRIPTION
# Issue
VPP forwarder sends file received from NSE as a `/proc/${pid}/fd/${fd}` to NSMgr. Such `pid/fd` pair is incorrect for NSMgr so it fails to send such file to the next hop.
```
Feb 19 05:43:27.617 [INFO] [name:nsmgr-k4mhq] (1) ⎆ sdk/pkg/networkservice/common/authorize/authorizeServer.Close() span=3ba9b39f56cf5f50:180a70f91b5184e6:3ba9b39f56cf5f50:1
Feb 19 05:43:27.617 [INFO] [name:nsmgr-k4mhq] (1.1)   request={"id":"b34e2416-0187-4785-8e8e-38464235f87f","network_service":"icmp-responder","mechanism":{"cls":"LOCAL","type":"KERNEL","parameters":{"inodeURL":"file:///proc/7/fd/16"}} ...
...
Feb 19 05:43:27.633 [INFO] [name:nsmgr-k4mhq] (25)                         ⎆ sdk/pkg/networkservice/common/mechanisms/sendfd/sendFDClient.Close() span=3ba9b39f56cf5f50:466e31146a990130:7a4a19874a65cfb9:1
Feb 19 05:43:27.633 [ERRO] [name:nsmgr-k4mhq] (25.1)                           stat /proc/7/fd/16: no such file or directory span=3ba9b39f56cf5f50:466e31146a990130:7a4a19874a65cfb9:1
```
# Solution
Add `sendfd.NewClient()` to `xconnectns` chain.