### PR TITLE
Fix routesClient on Close

### DIFF
--- a/pkg/networkservice/connectioncontext/ipcontext/routes/client.go
+++ b/pkg/networkservice/connectioncontext/ipcontext/routes/client.go
@@ -71,8 +71,6 @@ func (r *routesClient) Request(ctx context.Context, request *networkservice.Netw
 }
 
 func (r *routesClient) Close(ctx context.Context, conn *networkservice.Connection, opts ...grpc.CallOption) (*empty.Empty, error) {
-	if err := addDel(ctx, conn, r.vppConn, metadata.IsClient(r), false); err != nil {
-		return nil, err
-	}
+	_ = addDel(ctx, conn, r.vppConn, metadata.IsClient(r), false)
 	return next.Client(ctx).Close(ctx, conn, opts...)
 }


### PR DESCRIPTION
**Description**
Issue: https://github.com/networkservicemesh/deployments-k8s/issues/954
When `routesClient.Close()` is invoked because of SIGNAL, `vpp` process may already be killed. So, we cannot delete routes in this case, the chain of Closes is interrupted and will not be called on the next items.

**Solution**
Call `.Close()` before deleting routes.

Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>