### PR TITLE
Move pinhole to after the mechanism chain elements in both client and server.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	git.fd.io/govpp.git v0.3.6-0.20210202134006-4c1cccf48cd1
-	github.com/edwarnicke/govpp v0.0.0-20210225052125-79125273957c
+	github.com/edwarnicke/govpp v0.0.0-20210613224216-90cfa3213b00
 	github.com/golang/protobuf v1.4.3
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/networkservicemesh/api v0.0.0-20210609080649-aa4a0cc6c9ea

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/edwarnicke/exechelper v1.0.2/go.mod h1:/T271jtNX/ND4De6pa2aRy2+8sNtyCDB1A2pp4M+fUs=
-github.com/edwarnicke/govpp v0.0.0-20210225052125-79125273957c h1:Q9PEO4AHpwvd9Yd+WtA79h1NA1UpUl19WUMiUAF99i4=
-github.com/edwarnicke/govpp v0.0.0-20210225052125-79125273957c/go.mod h1:+J/hMuJr9nxWWHG+JJqhl+jpE4H97jO0tpvsaxSYEdU=
+github.com/edwarnicke/govpp v0.0.0-20210613224216-90cfa3213b00 h1:lbJYLHK/wiPcipTEn9/zpa33/lvVnpTvDkjzMCvuxac=
+github.com/edwarnicke/govpp v0.0.0-20210613224216-90cfa3213b00/go.mod h1:+J/hMuJr9nxWWHG+JJqhl+jpE4H97jO0tpvsaxSYEdU=
 github.com/edwarnicke/grpcfd v0.1.0 h1:f0lmmNDYawQaW+dMNoF8d4DxwPxxczNSFuvu5C7ptRk=
 github.com/edwarnicke/grpcfd v0.1.0/go.mod h1:rHihB9YvNMixz8rS+ZbwosI2kj65VLkeyYAI2M+/cGA=
 github.com/edwarnicke/serialize v0.0.0-20200705214914-ebc43080eecf/go.mod h1:XvbCO/QGsl3X8RzjBMoRpkm54FIAZH5ChK2j+aox7pw=

--- a/pkg/networkservice/chains/xconnectns/server.go
+++ b/pkg/networkservice/chains/xconnectns/server.go
@@ -79,12 +79,12 @@ func NewServer(ctx context.Context, name string, authzServer networkservice.Netw
 		connectioncontextkernel.NewServer(),
 		tag.NewServer(ctx, vppConn),
 		mtu.NewServer(vppConn),
-		pinhole.NewServer(vppConn),
 		mechanisms.NewServer(map[string]networkservice.NetworkServiceServer{
 			memif.MECHANISM:  memif.NewServer(vppConn),
 			kernel.MECHANISM: kernel.NewServer(vppConn),
 			vxlan.MECHANISM:  vxlan.NewServer(vppConn, tunnelIP),
 		}),
+		pinhole.NewServer(vppConn),
 		connect.NewServer(
 			ctx,
 			client.NewClientFactory(
@@ -95,11 +95,11 @@ func NewServer(ctx context.Context, name string, authzServer networkservice.Netw
 					stats.NewClient(ctx),
 					mtu.NewClient(vppConn),
 					tag.NewClient(ctx, vppConn),
-					pinhole.NewClient(vppConn),
 					// mechanisms
 					memif.NewClient(vppConn),
 					kernel.NewClient(vppConn),
 					vxlan.NewClient(vppConn, tunnelIP),
+					pinhole.NewClient(vppConn),
 					recvfd.NewClient(),
 					sendfd.NewClient()),
 			),


### PR DESCRIPTION
Both client and server chain elements make decisions and set parameters (say for mechanisms)
on the downward path of the call chain, and take action on the return path of the call chain.

For this reason, pinhole should open a 'pinhole' in any ACL *before* on the return chain
before the mechanism takes action to create a remote mechanism.

For vxlan this doesn't matter, as it is stateless.

For wireguard, which sends an initiator message on peer creation, it matters a lot.
If pinhole is misplaced (as it was previously), wireguard's initial initiator message
that is sent on peer creation is blocked as there is no pinhole for it.  Retries occur
after 5 seconds.  If pinhole is properly placed in the chain (as in this PR), then the initial
initiator message goes out, and the wireguard tunnel comes up within milliseconds.

Also update to the latest github.com/edwarnicke/govpp which contains wireguard API
enhancement to allow us to 'wait' till peers are up.

Signed-off-by: Ed Warnicke <hagbard@gmail.com>
