### PR TITLE
Fix order of memif cleanup on close.

### DIFF
--- a/pkg/networkservice/mechanisms/memif/client.go
+++ b/pkg/networkservice/mechanisms/memif/client.go
@@ -80,12 +80,6 @@ func (m *memifClient) Request(ctx context.Context, request *networkservice.Netwo
 }
 
 func (m *memifClient) Close(ctx context.Context, conn *networkservice.Connection, opts ...grpc.CallOption) (*empty.Empty, error) {
-	rv, err := next.Client(ctx).Close(ctx, conn, opts...)
-	if err != nil {
-		return nil, err
-	}
-	if err := del(ctx, conn, m.vppConn, metadata.IsClient(m)); err != nil {
-		return nil, err
-	}
-	return rv, nil
+	_ = del(ctx, conn, m.vppConn, metadata.IsClient(m))
+	return next.Client(ctx).Close(ctx, conn, opts...)
 }

--- a/pkg/networkservice/mechanisms/memif/server.go
+++ b/pkg/networkservice/mechanisms/memif/server.go
@@ -51,9 +51,6 @@ func (m *memifServer) Request(ctx context.Context, request *networkservice.Netwo
 }
 
 func (m *memifServer) Close(ctx context.Context, conn *networkservice.Connection) (*empty.Empty, error) {
-	rv, err := next.Server(ctx).Close(ctx, conn)
-	if delErr := del(ctx, conn, m.vppConn, metadata.IsClient(m)); delErr != nil {
-		return nil, delErr
-	}
-	return rv, err
+	_ = del(ctx, conn, m.vppConn, metadata.IsClient(m))
+	return next.Server(ctx).Close(ctx, conn)
 }


### PR DESCRIPTION
Turns out this was causing a heisenbug.  Fixed.

Signed-off-by: Ed Warnicke <hagbard@gmail.com>
