### PR TITLE
More fixes for order of operations

### DIFF
--- a/pkg/networkservice/mechanisms/kernel/kerneltap/client.go
+++ b/pkg/networkservice/mechanisms/kernel/kerneltap/client.go
@@ -61,12 +61,6 @@ func (k *kernelTapClient) Request(ctx context.Context, request *networkservice.N
 }
 
 func (k *kernelTapClient) Close(ctx context.Context, conn *networkservice.Connection, opts ...grpc.CallOption) (*empty.Empty, error) {
-	rv, err := next.Client(ctx).Close(ctx, conn, opts...)
-	if err != nil {
-		return nil, err
-	}
-	if err := del(ctx, conn, k.vppConn, metadata.IsClient(k)); err != nil {
-		return nil, err
-	}
-	return rv, nil
+	_ = del(ctx, conn, k.vppConn, metadata.IsClient(k))
+	return next.Client(ctx).Close(ctx, conn, opts...)
 }

--- a/pkg/networkservice/mechanisms/kernel/kerneltap/server.go
+++ b/pkg/networkservice/mechanisms/kernel/kerneltap/server.go
@@ -53,8 +53,6 @@ func (k *kernelTapServer) Request(ctx context.Context, request *networkservice.N
 }
 
 func (k *kernelTapServer) Close(ctx context.Context, conn *networkservice.Connection) (*empty.Empty, error) {
-	if err := del(ctx, conn, k.vppConn, metadata.IsClient(k)); err != nil {
-		return nil, err
-	}
+	_ = del(ctx, conn, k.vppConn, metadata.IsClient(k))
 	return next.Server(ctx).Close(ctx, conn)
 }

--- a/pkg/networkservice/mechanisms/kernel/kernelvethpair/afpacket/client.go
+++ b/pkg/networkservice/mechanisms/kernel/kernelvethpair/afpacket/client.go
@@ -54,12 +54,6 @@ func (a *afPacketClient) Request(ctx context.Context, request *networkservice.Ne
 }
 
 func (a *afPacketClient) Close(ctx context.Context, conn *networkservice.Connection, opts ...grpc.CallOption) (*empty.Empty, error) {
-	rv, err := next.Client(ctx).Close(ctx, conn, opts...)
-	if err != nil {
-		return nil, err
-	}
-	if err := del(ctx, conn, a.vppConn, metadata.IsClient(a)); err != nil {
-		return nil, err
-	}
-	return rv, nil
+	_ = del(ctx, conn, a.vppConn, metadata.IsClient(a))
+	return next.Client(ctx).Close(ctx, conn, opts...)
 }

--- a/pkg/networkservice/mechanisms/kernel/kernelvethpair/afpacket/server.go
+++ b/pkg/networkservice/mechanisms/kernel/kernelvethpair/afpacket/server.go
@@ -52,8 +52,6 @@ func (a *afPacketServer) Request(ctx context.Context, request *networkservice.Ne
 }
 
 func (a *afPacketServer) Close(ctx context.Context, conn *networkservice.Connection) (*empty.Empty, error) {
-	if err := del(ctx, conn, a.vppConn, false); err != nil {
-		return nil, err
-	}
+	_ = del(ctx, conn, a.vppConn, false)
 	return next.Server(ctx).Close(ctx, conn)
 }

--- a/pkg/networkservice/mechanisms/kernel/kernelvethpair/client.go
+++ b/pkg/networkservice/mechanisms/kernel/kernelvethpair/client.go
@@ -65,12 +65,6 @@ func (k *kernelVethPairClient) Request(ctx context.Context, request *networkserv
 }
 
 func (k *kernelVethPairClient) Close(ctx context.Context, conn *networkservice.Connection, opts ...grpc.CallOption) (*empty.Empty, error) {
-	rv, err := next.Client(ctx).Close(ctx, conn, opts...)
-	if err != nil {
-		return nil, err
-	}
-	if err := del(ctx, conn, metadata.IsClient(k)); err != nil {
-		return nil, err
-	}
-	return rv, nil
+	_ = del(ctx, conn, metadata.IsClient(k))
+	return next.Client(ctx).Close(ctx, conn, opts...)
 }

--- a/pkg/networkservice/mechanisms/kernel/kernelvethpair/server.go
+++ b/pkg/networkservice/mechanisms/kernel/kernelvethpair/server.go
@@ -59,8 +59,6 @@ func (k *kernelVethPairServer) Request(ctx context.Context, request *networkserv
 }
 
 func (k *kernelVethPairServer) Close(ctx context.Context, conn *networkservice.Connection) (*empty.Empty, error) {
-	if err := del(ctx, conn, metadata.IsClient(k)); err != nil {
-		return nil, err
-	}
+	_ = del(ctx, conn, metadata.IsClient(k))
 	return next.Server(ctx).Close(ctx, conn)
 }

--- a/pkg/networkservice/mechanisms/vxlan/client.go
+++ b/pkg/networkservice/mechanisms/vxlan/client.go
@@ -82,12 +82,6 @@ func (v *vxlanClient) Close(ctx context.Context, conn *networkservice.Connection
 	if conn.GetPayload() != payload.Ethernet {
 		return next.Client(ctx).Close(ctx, conn, opts...)
 	}
-	rv, err := next.Client(ctx).Close(ctx, conn, opts...)
-	if err != nil {
-		return nil, err
-	}
-	if err := addDel(ctx, conn, v.vppConn, false, metadata.IsClient(v)); err != nil {
-		return nil, err
-	}
-	return rv, nil
+	_ = addDel(ctx, conn, v.vppConn, false, metadata.IsClient(v))
+	return next.Client(ctx).Close(ctx, conn, opts...)
 }

--- a/pkg/networkservice/mechanisms/vxlan/server.go
+++ b/pkg/networkservice/mechanisms/vxlan/server.go
@@ -76,8 +76,6 @@ func (v *vxlanServer) Close(ctx context.Context, conn *networkservice.Connection
 	if conn.GetPayload() != payload.Ethernet {
 		return next.Server(ctx).Close(ctx, conn)
 	}
-	if err := addDel(ctx, conn, v.vppConn, false, false); err != nil {
-		return nil, err
-	}
+	_ = addDel(ctx, conn, v.vppConn, false, false)
 	return next.Server(ctx).Close(ctx, conn)
 }

--- a/pkg/networkservice/xconnect/l2xconnect/client.go
+++ b/pkg/networkservice/xconnect/l2xconnect/client.go
@@ -58,12 +58,6 @@ func (v *l2XConnectServer) Close(ctx context.Context, conn *networkservice.Conne
 	if conn.GetPayload() != payload.Ethernet {
 		return next.Client(ctx).Close(ctx, conn, opts...)
 	}
-	rv, err := next.Client(ctx).Close(ctx, conn, opts...)
-	if err != nil {
-		return nil, err
-	}
-	if err := addDel(ctx, v.vppConn, false); err != nil {
-		return nil, err
-	}
-	return rv, nil
+	_ = addDel(ctx, v.vppConn, false)
+	return next.Client(ctx).Close(ctx, conn, opts...)
 }

--- a/pkg/networkservice/xconnect/l3xconnect/client.go
+++ b/pkg/networkservice/xconnect/l3xconnect/client.go
@@ -59,12 +59,6 @@ func (v *l3XConnectServer) Close(ctx context.Context, conn *networkservice.Conne
 	if conn.GetPayload() != payload.IP {
 		return next.Client(ctx).Close(ctx, conn, opts...)
 	}
-	rv, err := next.Client(ctx).Close(ctx, conn, opts...)
-	if err != nil {
-		return nil, err
-	}
-	if err := del(ctx, v.vppConn); err != nil {
-		return nil, err
-	}
-	return rv, nil
+	_ = del(ctx, v.vppConn)
+	return next.Client(ctx).Close(ctx, conn, opts...)
 }


### PR DESCRIPTION
Close should always cleanup *first*, then call next.
Close should never stop calling next just because its local cleanup failed.

Signed-off-by: Ed Warnicke <hagbard@gmail.com>
