### PR TITLE
Save the IP-addresses assigned to the interface

### DIFF
--- a/pkg/networkservice/connectioncontext/ipcontext/ipaddress/metadata.go
+++ b/pkg/networkservice/connectioncontext/ipcontext/ipaddress/metadata.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipaddress
+
+import (
+	"context"
+	"net"
+
+	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/metadata"
+)
+
+type key struct{}
+
+func store(ctx context.Context, isClient bool, ips []*net.IPNet) {
+	metadata.Map(ctx, isClient).Store(key{}, ips)
+}
+
+func delete(ctx context.Context, isClient bool) {
+	metadata.Map(ctx, isClient).Delete(key{})
+}
+
+func load(ctx context.Context, isClient bool) (value []*net.IPNet, ok bool) {
+	rawValue, ok := metadata.Map(ctx, isClient).Load(key{})
+	if !ok {
+		return
+	}
+	value, ok = rawValue.([]*net.IPNet)
+	return value, ok
+}


### PR DESCRIPTION
#306
Save the IP-addresses assigned to the interface. 
We cannot call `.SwInterfaceAddDelAddress(...)` on refresh again, because vpp generates an error.

Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>