### PR TITLE
[qfix] Fix stats client returning nil conn on init error

### DIFF
--- a/pkg/networkservice/stats/client.go
+++ b/pkg/networkservice/stats/client.go
@@ -50,10 +50,12 @@ func (s *statsClient) Request(ctx context.Context, request *networkservice.Netwo
 	if initErr != nil {
 		log.FromContext(ctx).Errorf("%v", initErr)
 	}
+
 	conn, err := next.Client(ctx).Request(ctx, request, opts...)
 	if err != nil || initErr != nil {
-		return nil, err
+		return conn, err
 	}
+
 	retrieveMetrics(ctx, s.statsConn, conn.Path.PathSegments[conn.Path.Index], true)
 	return conn, nil
 }

--- a/pkg/networkservice/stats/server.go
+++ b/pkg/networkservice/stats/server.go
@@ -48,6 +48,7 @@ func (s *statsServer) Request(ctx context.Context, request *networkservice.Netwo
 	if initErr != nil {
 		log.FromContext(ctx).Errorf("%v", initErr)
 	}
+
 	conn, err := next.Server(ctx).Request(ctx, request)
 	if err != nil || initErr != nil {
 		return conn, err


### PR DESCRIPTION
## Description
Fixes stats client to return `conn` instead of `nil` on Request if `initErr != nil`.

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
