### PR TITLE
[qfix] Close VPP dump clients

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 ---
 run:
   # concurrency: 6
-  timeout: 1m
+  timeout: 1.5m
   issues-exit-code: 1
   tests: true
 linters-settings:

--- a/pkg/networkservice/pinhole/common.go
+++ b/pkg/networkservice/pinhole/common.go
@@ -138,6 +138,7 @@ func aclDetails(ctx context.Context, vppConn api.Connection, aclIndeces []uint32
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
+		defer func() { _ = aclDumpClient.Close() }()
 		aclDetails, err := aclDumpClient.Recv()
 		if err != nil {
 			return nil, errors.WithStack(err)

--- a/pkg/networkservice/up/common.go
+++ b/pkg/networkservice/up/common.go
@@ -83,6 +83,8 @@ func waitForUpLinkUp(ctx context.Context, vppConn api.Connection, apiChannel api
 	if err != nil {
 		return errors.WithStack(err)
 	}
+	defer func() { _ = dc.Close() }()
+
 	details, err := dc.Recv()
 	if err != nil {
 		return errors.Wrapf(err, "error retrieving SwInterfaceDetails for swIfIndex %d", swIfIndex)
@@ -92,10 +94,12 @@ func waitForUpLinkUp(ctx context.Context, vppConn api.Connection, apiChannel api
 		WithField("details.Flags", details.Flags).
 		WithField("duration", time.Since(now)).
 		WithField("vppapi", "SwInterfaceDump").Debug("completed")
+
 	isUp := details.Flags & interface_types.IF_STATUS_API_FLAG_LINK_UP
 	if isUp != 0 {
 		return nil
 	}
+
 	now = time.Now()
 	for {
 		select {

--- a/pkg/networkservice/up/peerup/common.go
+++ b/pkg/networkservice/up/peerup/common.go
@@ -56,12 +56,15 @@ func waitForPeerUp(ctx context.Context, vppConn Connection, pubKey string, isCli
 	defer func() { _ = subscription.Unsubscribe() }()
 
 	now := time.Now()
+
 	dp, err := wireguard.NewServiceClient(vppConn).WireguardPeersDump(ctx, &wireguard.WireguardPeersDump{
 		PeerIndex: peerIndex,
 	})
 	if err != nil {
 		return errors.WithStack(err)
 	}
+	defer func() { _ = dp.Close() }()
+
 	details, err := dp.Recv()
 	if err != nil {
 		return errors.Wrapf(err, "error retrieving WireguardPeersDetails")


### PR DESCRIPTION
## Description
Closes VPP dump clients to prevent memory leaks.

## Related issue
https://github.com/networkservicemesh/deployments-k8s/issues/2381