### PR TITLE
[qfix] Fix error handling in memifproxy

### DIFF
--- a/pkg/networkservice/mechanisms/memif/memifproxy/proxy_listener.go
+++ b/pkg/networkservice/mechanisms/memif/memifproxy/proxy_listener.go
@@ -66,12 +66,12 @@ func (p *proxyListener) accept() {
 	defer func() { _ = p.Close() }()
 	for {
 		in, err := p.listener.Accept()
-		if optErr, ok := err.(*net.OpError); ok && !optErr.Temporary() {
+		if optErr, ok := err.(*net.OpError); !ok || !optErr.Temporary() {
 			// TODO - perhaps log this?
 			return
 		}
 		out, err := net.Dial(memifNetwork, p.socketFilename)
-		if optErr, ok := err.(*net.OpError); ok && !optErr.Temporary() {
+		if optErr, ok := err.(*net.OpError); !ok || !optErr.Temporary() {
 			_ = in.Close()
 			// TODO - perhaps log this?
 			return


### PR DESCRIPTION
## Description
Fixes error handling in `memifproxy`.

## Motivation
If `err` is not `*net.OpError` it doesn't return and passes `nil` `in` further in `copy` method.

Found in https://github.com/networkservicemesh/deployments-k8s/issues/2381#issuecomment-940120379 logs:
[forwarder_old_8.zip](https://github.com/networkservicemesh/deployments-k8s/files/7322924/forwarder_old_8.zip)

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [x] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
