### PR TITLE
[qfix] Check if error is nil in proxy listener

### DIFF
--- a/pkg/networkservice/mechanisms/memif/memifproxy/proxy_listener.go
+++ b/pkg/networkservice/mechanisms/memif/memifproxy/proxy_listener.go
@@ -66,16 +66,22 @@ func (p *proxyListener) accept() {
 	defer func() { _ = p.Close() }()
 	for {
 		in, err := p.listener.Accept()
-		if optErr, ok := err.(*net.OpError); !ok || !optErr.Temporary() {
-			// TODO - perhaps log this?
-			return
+		if err != nil {
+			if optErr, ok := err.(*net.OpError); !ok || !optErr.Temporary() {
+				// TODO - perhaps log this?
+				return
+			}
 		}
+
 		out, err := net.Dial(memifNetwork, p.socketFilename)
-		if optErr, ok := err.(*net.OpError); !ok || !optErr.Temporary() {
-			_ = in.Close()
-			// TODO - perhaps log this?
-			return
+		if err != nil {
+			if optErr, ok := err.(*net.OpError); !ok || !optErr.Temporary() {
+				_ = in.Close()
+				// TODO - perhaps log this?
+				return
+			}
 		}
+
 		proxyConn, err := newProxyConnection(in, out)
 		if err != nil {
 			_ = in.Close()
@@ -83,6 +89,7 @@ func (p *proxyListener) accept() {
 			// TODO - perhaps log this?
 			return
 		}
+
 		// TODO - clean up - while 99% of the time this won't be an issue because we will have exactly one thing
 		//        in this list... in principle it could leak memory
 		p.proxyConnections = append(p.proxyConnections, proxyConn)


### PR DESCRIPTION
## Description
Continues #403 and fixes introduced error.

## Motivation
If `err` is nil `ok` will also be `false`.

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
