### PR TITLE
Revert "Fix/revert (#410)"

### DIFF
--- a/pkg/networkservice/mechanisms/memif/memifproxy/proxy_listener.go
+++ b/pkg/networkservice/mechanisms/memif/memifproxy/proxy_listener.go
@@ -66,16 +66,22 @@ func (p *proxyListener) accept() {
 	defer func() { _ = p.Close() }()
 	for {
 		in, err := p.listener.Accept()
-		if optErr, ok := err.(*net.OpError); ok && !optErr.Temporary() {
-			// TODO - perhaps log this?
-			return
+		if err != nil {
+			if optErr, ok := err.(*net.OpError); !ok || !optErr.Temporary() {
+				// TODO - perhaps log this?
+				return
+			}
 		}
+
 		out, err := net.Dial(memifNetwork, p.socketFilename)
-		if optErr, ok := err.(*net.OpError); ok && !optErr.Temporary() {
-			_ = in.Close()
-			// TODO - perhaps log this?
-			return
+		if err != nil {
+			if optErr, ok := err.(*net.OpError); !ok || !optErr.Temporary() {
+				_ = in.Close()
+				// TODO - perhaps log this?
+				return
+			}
 		}
+
 		proxyConn, err := newProxyConnection(in, out)
 		if err != nil {
 			_ = in.Close()
@@ -83,6 +89,7 @@ func (p *proxyListener) accept() {
 			// TODO - perhaps log this?
 			return
 		}
+
 		// TODO - clean up - while 99% of the time this won't be an issue because we will have exactly one thing
 		//        in this list... in principle it could leak memory
 		p.proxyConnections = append(p.proxyConnections, proxyConn)


### PR DESCRIPTION
This reverts commit d541552ca8a75892013e1a9a269a433c111053bb.

## Description
Changes are working, error was on CI because of not updated cmd-nse-firewall-vpp version.
https://github.com/networkservicemesh/deployments-k8s/blame/ae9f8f8a82b9303beab3d36d606263cf4c21b90a/images.yaml#L8

Valid version should be `68bed4e`, because:
1. PR introducing new version - networkservicemesh/cmd-nse-firewall-vpp#84.
2. workflow run triggered by this PR - https://github.com/networkservicemesh/cmd-nse-firewall-vpp/runs/3879037037?check_suite_focus=true#step:7:5

## Issue
Closes #411.