### PR TITLE
Update VPP to match latest Calico-VPP patches

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	git.fd.io/govpp.git v0.3.6-0.20210927044411-385ccc0d8ba9
-	github.com/edwarnicke/govpp v0.0.0-20211023203533-76f2c92be8d5
+	github.com/edwarnicke/govpp v0.0.0-20211101202831-a045363b0c36
 	github.com/golang/protobuf v1.4.3
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/networkservicemesh/api v1.0.1-0.20210907194827-9a36433d7d6e

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/edwarnicke/exechelper v1.0.2/go.mod h1:/T271jtNX/ND4De6pa2aRy2+8sNtyCDB1A2pp4M+fUs=
-github.com/edwarnicke/govpp v0.0.0-20211023203533-76f2c92be8d5 h1:LzR4g5d/6a/XtiKGdsRmy92ZepFT5dKSl5v2BQ0FRZU=
-github.com/edwarnicke/govpp v0.0.0-20211023203533-76f2c92be8d5/go.mod h1:kHDnxA+SSNFeMEHz7xvhub1zvx4mOTRlWWRCay2n5NM=
+github.com/edwarnicke/govpp v0.0.0-20211101202831-a045363b0c36 h1:4SBFlaF0UD94vXw6xx2Bai47HXLDsS7tbjL2ijPXRog=
+github.com/edwarnicke/govpp v0.0.0-20211101202831-a045363b0c36/go.mod h1:kHDnxA+SSNFeMEHz7xvhub1zvx4mOTRlWWRCay2n5NM=
 github.com/edwarnicke/grpcfd v0.1.1 h1:ej5J1V7iSRa4RF1OIXfaVKsEWCMLIGiNECLgh7juxBA=
 github.com/edwarnicke/grpcfd v0.1.1/go.mod h1:rHihB9YvNMixz8rS+ZbwosI2kj65VLkeyYAI2M+/cGA=
 github.com/edwarnicke/serialize v0.0.0-20200705214914-ebc43080eecf/go.mod h1:XvbCO/QGsl3X8RzjBMoRpkm54FIAZH5ChK2j+aox7pw=


### PR DESCRIPTION
https://github.com/edwarnicke/govpp/blob/a045363b0c3639c14685dc550b9592ad6ef96310/patch/patch.sh#L15-L26

Signed-off-by: Ed Warnicke <hagbard@gmail.com>
