### PR TITLE
qfix: Add dial timeout for chains/forwarder

### DIFF
--- a/pkg/networkservice/chains/forwarder/server.go
+++ b/pkg/networkservice/chains/forwarder/server.go
@@ -69,7 +69,7 @@ type xconnectNSServer struct {
 }
 
 // NewServer - returns an implementation of the xconnectns network service
-func NewServer(ctx context.Context, name string, authzServer networkservice.NetworkServiceServer, tokenGenerator token.GeneratorFunc, clientURL *url.URL, vppConn Connection, tunnelIP net.IP, tunnelPort uint16, clientDialOptions ...grpc.DialOption) endpoint.Endpoint {
+func NewServer(ctx context.Context, name string, authzServer networkservice.NetworkServiceServer, tokenGenerator token.GeneratorFunc, clientURL *url.URL, vppConn Connection, tunnelIP net.IP, tunnelPort uint16, dialTimeout time.Duration, clientDialOptions ...grpc.DialOption) endpoint.Endpoint {
 	nseClient := registryclient.NewNetworkServiceEndpointRegistryClient(ctx, clientURL,
 		registryclient.WithNSEAdditionalFunctionality(registryrecvfd.NewNetworkServiceEndpointRegistryClient()),
 		registryclient.WithDialOptions(clientDialOptions...),
@@ -100,6 +100,7 @@ func NewServer(ctx context.Context, name string, authzServer networkservice.Netw
 				client.WithoutRefresh(),
 				client.WithName(name),
 				client.WithDialOptions(clientDialOptions...),
+				client.WithDialTimeout(dialTimeout),
 				client.WithAdditionalFunctionality(
 					mechanismtranslation.NewClient(),
 					connectioncontextkernel.NewClient(),

--- a/pkg/networkservice/chains/forwarder/server.go
+++ b/pkg/networkservice/chains/forwarder/server.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"net"
 	"net/url"
+	"time"
 
 	"git.fd.io/govpp.git/api"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/client"


### PR DESCRIPTION
Signed-off-by: denis-tingaikin <denis.tingajkin@xored.com>

## Motivation

Since forwarders connect to endpoints we need to prevent connection to dead nses as soon as possible with dialTimeout.