### PR TITLE
Fix kernel mechanisms for healing cases

### DIFF
--- a/pkg/networkservice/mechanisms/kernel/kerneltap/common.go
+++ b/pkg/networkservice/mechanisms/kernel/kerneltap/common.go
@@ -43,7 +43,7 @@ func create(ctx context.Context, conn *networkservice.Connection, vppConn api.Co
 		// Construct the netlink handle for the target namespace for this kernel interface
 		handle, err := kernellink.GetNetlinkHandle(mechanism.GetNetNSURL())
 		if err != nil {
-			return err
+			return errors.WithStack(err)
 		}
 		defer handle.Delete()
 

--- a/pkg/networkservice/mechanisms/kernel/kerneltap/common.go
+++ b/pkg/networkservice/mechanisms/kernel/kerneltap/common.go
@@ -40,9 +40,20 @@ import (
 
 func create(ctx context.Context, conn *networkservice.Connection, vppConn api.Connection, isClient bool) error {
 	if mechanism := kernel.ToMechanism(conn.GetMechanism()); mechanism != nil {
-		if _, ok := ifindex.Load(ctx, isClient); ok {
-			return nil
+		// Construct the netlink handle for the target namespace for this kernel interface
+		handle, err := kernellink.GetNetlinkHandle(mechanism.GetNetNSURL())
+		if err != nil {
+			return err
 		}
+		defer handle.Delete()
+
+		if _, ok := ifindex.Load(ctx, isClient); ok {
+			if _, err = handle.LinkByName(mechanism.GetInterfaceName()); err == nil {
+				return nil
+			}
+		}
+		// Delete the kernel interface if there is one in the target namespace
+		_ = del(ctx, conn, vppConn, isClient)
 
 		nsFilename, err := mechutils.ToNSFilename(mechanism)
 		if err != nil {
@@ -92,11 +103,6 @@ func create(ctx context.Context, conn *networkservice.Connection, vppConn api.Co
 			WithField("mode", interface_types.RX_MODE_API_ADAPTIVE).
 			WithField("duration", time.Since(now)).
 			WithField("vppapi", "SwInterfaceSetRxMode").Debug("completed")
-
-		handle, err := kernellink.GetNetlinkHandle(mechanism.GetNetNSURL())
-		if err != nil {
-			return err
-		}
 
 		now = time.Now()
 		l, err := handle.LinkByName(tapCreateV2.HostIfName)

--- a/pkg/networkservice/mechanisms/kernel/kernelvethpair/common.go
+++ b/pkg/networkservice/mechanisms/kernel/kernelvethpair/common.go
@@ -56,14 +56,15 @@ func create(ctx context.Context, conn *networkservice.Connection, isClient bool)
 			}
 		}
 
-		// Delete the kernel interface if there is one in the target namespace
-		if l, e := handle.LinkByName(mechanism.GetInterfaceName()); e == nil {
+		// Delete the previous kernel interface if there is one in the target namespace
+		var prevLink netlink.Link
+		if prevLink, err = handle.LinkByName(mechanism.GetInterfaceName()); err == nil {
 			now := time.Now()
-			if e = handle.LinkDel(l); e != nil {
-				return errors.WithStack(e)
+			if err = handle.LinkDel(prevLink); err != nil {
+				return errors.WithStack(err)
 			}
 			log.FromContext(ctx).
-				WithField("link.Name", l.Attrs().Name).
+				WithField("link.Name", prevLink.Attrs().Name).
 				WithField("duration", time.Since(now)).
 				WithField("netlink", "LinkDel").Debug("completed")
 		}


### PR DESCRIPTION
Issue: https://github.com/networkservicemesh/sdk/issues/1196

## Motivation
For example, `NSMgr + NSE` died. Forwarder doesn't know about NSE death and doesn't receive `Close` from the client (because NSMgr is also died). But it stores `ifindex` in metadata that belongs to the old NSE interface.

## Solution
We need to additionally check the interface by name and delete it if we find the old one.

Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>