### PR TITLE
Update memif mechanismPreference NetNSURL on Request

### DIFF
--- a/pkg/networkservice/mechanisms/memif/client.go
+++ b/pkg/networkservice/mechanisms/memif/client.go
@@ -22,6 +22,7 @@ package memif
 
 import (
 	"context"
+	"net/url"
 
 	"git.fd.io/govpp.git/api"
 	"github.com/golang/protobuf/ptypes/empty"
@@ -112,7 +113,7 @@ func (m *memifClient) updateMechanismPreferences(request *networkservice.Network
 	var updated = false
 	for _, p := range request.GetRequestMechanismPreferences() {
 		if mechanism := memif.ToMechanism(p); mechanism != nil {
-			mechanism.SetNetNSURL(memif.ToMechanism(memif.NewAbstract(m.nsInfo.netNSPath)).GetNetNSURL())
+			mechanism.SetNetNSURL((&url.URL{Scheme: memif.FileScheme, Path: m.nsInfo.netNSPath}).String())
 			if m.changeNetNs {
 				mechanism.SetNetNSURL("")
 			}


### PR DESCRIPTION
Issue: https://github.com/networkservicemesh/sdk/issues/1196

## Motivation
We need to update `NetNSURL` for memif mechanism preference, because there might be a wrong value after previous use.

Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>