### PR TITLE
Fix chain elements init function

### DIFF
--- a/pkg/networkservice/mechanisms/vxlan/mtu/client.go
+++ b/pkg/networkservice/mechanisms/vxlan/mtu/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Cisco and/or its affiliates.
+// Copyright (c) 2021-2022 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -20,11 +20,13 @@ import (
 	"context"
 	"net"
 	"sync"
+	"sync/atomic"
 
 	"git.fd.io/govpp.git/api"
-	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
 
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
 	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/vxlan"
@@ -34,8 +36,9 @@ type mtuClient struct {
 	vppConn  api.Connection
 	tunnelIP net.IP
 	mtu      uint32
-	initOnce sync.Once
-	err      error
+
+	inited    uint32
+	initMutex sync.Mutex
 }
 
 // NewClient - returns client chain element to manage vxlan MTU
@@ -70,8 +73,19 @@ func (m *mtuClient) Close(ctx context.Context, conn *networkservice.Connection, 
 }
 
 func (m *mtuClient) init(ctx context.Context) error {
-	m.initOnce.Do(func() {
-		m.mtu, m.err = setMTU(ctx, m.vppConn, m.tunnelIP)
-	})
-	return m.err
+	if atomic.LoadUint32(&m.inited) > 0 {
+		return nil
+	}
+	m.initMutex.Lock()
+	defer m.initMutex.Unlock()
+	if atomic.LoadUint32(&m.inited) > 0 {
+		return nil
+	}
+
+	var err error
+	m.mtu, err = getMTU(ctx, m.vppConn, m.tunnelIP)
+	if err == nil {
+		atomic.StoreUint32(&m.inited, 1)
+	}
+	return err
 }

--- a/pkg/networkservice/mechanisms/vxlan/mtu/common.go
+++ b/pkg/networkservice/mechanisms/vxlan/mtu/common.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 Cisco and/or its affiliates.
+// Copyright (c) 2020-2022 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -34,7 +34,7 @@ const (
 	overhead = 50
 )
 
-func setMTU(ctx context.Context, vppConn api.Connection, tunnelIP net.IP) (uint32, error) {
+func getMTU(ctx context.Context, vppConn api.Connection, tunnelIP net.IP) (uint32, error) {
 	client, err := interfaces.NewServiceClient(vppConn).SwInterfaceDump(ctx, &interfaces.SwInterfaceDump{})
 	if err != nil {
 		return 0, errors.Wrapf(err, "error attempting to get interface dump client to determine MTU for tunnelIP %q", tunnelIP)

--- a/pkg/networkservice/mechanisms/vxlan/mtu/server.go
+++ b/pkg/networkservice/mechanisms/vxlan/mtu/server.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Cisco and/or its affiliates.
+// Copyright (c) 2021-2022 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -20,10 +20,12 @@ import (
 	"context"
 	"net"
 	"sync"
+	"sync/atomic"
 
 	"git.fd.io/govpp.git/api"
-	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
 	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
 
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
 	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/vxlan"
@@ -33,8 +35,9 @@ type mtuServer struct {
 	vppConn  api.Connection
 	tunnelIP net.IP
 	mtu      uint32
-	initOnce sync.Once
-	err      error
+
+	inited    uint32
+	initMutex sync.Mutex
 }
 
 // NewServer - server chain element to manage vxlan MTU
@@ -76,8 +79,19 @@ func (m *mtuServer) Close(ctx context.Context, conn *networkservice.Connection) 
 }
 
 func (m *mtuServer) init(ctx context.Context) error {
-	m.initOnce.Do(func() {
-		m.mtu, m.err = setMTU(ctx, m.vppConn, m.tunnelIP)
-	})
-	return m.err
+	if atomic.LoadUint32(&m.inited) > 0 {
+		return nil
+	}
+	m.initMutex.Lock()
+	defer m.initMutex.Unlock()
+	if atomic.LoadUint32(&m.inited) > 0 {
+		return nil
+	}
+
+	var err error
+	m.mtu, err = getMTU(ctx, m.vppConn, m.tunnelIP)
+	if err == nil {
+		atomic.StoreUint32(&m.inited, 1)
+	}
+	return err
 }

--- a/pkg/networkservice/mechanisms/wireguard/mtu/client.go
+++ b/pkg/networkservice/mechanisms/wireguard/mtu/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Cisco and/or its affiliates.
+// Copyright (c) 2021-2022 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -20,6 +20,7 @@ import (
 	"context"
 	"net"
 	"sync"
+	"sync/atomic"
 
 	"git.fd.io/govpp.git/api"
 	"google.golang.org/grpc"
@@ -35,8 +36,9 @@ type mtuClient struct {
 	vppConn  api.Connection
 	tunnelIP net.IP
 	mtu      uint32
-	initOnce sync.Once
-	err      error
+
+	inited    uint32
+	initMutex sync.Mutex
 }
 
 // NewClient - returns client chain element to manage wireguard MTU
@@ -71,8 +73,19 @@ func (m *mtuClient) Close(ctx context.Context, conn *networkservice.Connection, 
 }
 
 func (m *mtuClient) init(ctx context.Context) error {
-	m.initOnce.Do(func() {
-		m.mtu, m.err = setMTU(ctx, m.vppConn, m.tunnelIP)
-	})
-	return m.err
+	if atomic.LoadUint32(&m.inited) > 0 {
+		return nil
+	}
+	m.initMutex.Lock()
+	defer m.initMutex.Unlock()
+	if atomic.LoadUint32(&m.inited) > 0 {
+		return nil
+	}
+
+	var err error
+	m.mtu, err = getMTU(ctx, m.vppConn, m.tunnelIP)
+	if err == nil {
+		atomic.StoreUint32(&m.inited, 1)
+	}
+	return err
 }

--- a/pkg/networkservice/mechanisms/wireguard/mtu/common.go
+++ b/pkg/networkservice/mechanisms/wireguard/mtu/common.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 Cisco and/or its affiliates.
+// Copyright (c) 2020-2022 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -34,7 +34,7 @@ const (
 	overhead = 80
 )
 
-func setMTU(ctx context.Context, vppConn api.Connection, tunnelIP net.IP) (uint32, error) {
+func getMTU(ctx context.Context, vppConn api.Connection, tunnelIP net.IP) (uint32, error) {
 	client, err := interfaces.NewServiceClient(vppConn).SwInterfaceDump(ctx, &interfaces.SwInterfaceDump{})
 	if err != nil {
 		return 0, errors.Wrapf(err, "error attempting to get interface dump client to determine MTU for tunnelIP %q", tunnelIP)

--- a/pkg/networkservice/up/peerup/client.go
+++ b/pkg/networkservice/up/peerup/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Doc.ai and/or its affiliates.
+// Copyright (c) 2021-2022 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -19,7 +19,6 @@ package peerup
 
 import (
 	"context"
-	"sync"
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/pkg/errors"
@@ -35,7 +34,6 @@ import (
 type peerupClient struct {
 	ctx     context.Context
 	vppConn Connection
-	sync.Once
 }
 
 // NewClient provides a NetworkServiceClient chain elements that 'up's the peer


### PR DESCRIPTION
Closes: https://github.com/networkservicemesh/deployments-k8s/issues/2800

### Motivation
If context was canceled (e.g by timeout) in the middle of the chain, and the next chain element has `init` function with `sync.Once` - we have no chance to call `init` again. We store the error and all new Requests will fail with that error.

### Solution
Call the `init` function only the first time, OR if the first call returned an error.

Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>