### PR TITLE
Govpp update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	git.fd.io/govpp.git v0.3.6-0.20210927044411-385ccc0d8ba9
-	github.com/edwarnicke/govpp v0.0.0-20211023203533-76f2c92be8d5
+	github.com/edwarnicke/govpp v0.0.0-20220311182453-f32f292e0e91
 	github.com/golang/protobuf v1.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/networkservicemesh/api v1.1.2-0.20220119092736-21eda250c390

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,8 @@ github.com/eapache/go-resiliency v1.2.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5m
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/edwarnicke/exechelper v1.0.2/go.mod h1:/T271jtNX/ND4De6pa2aRy2+8sNtyCDB1A2pp4M+fUs=
-github.com/edwarnicke/govpp v0.0.0-20211023203533-76f2c92be8d5 h1:LzR4g5d/6a/XtiKGdsRmy92ZepFT5dKSl5v2BQ0FRZU=
-github.com/edwarnicke/govpp v0.0.0-20211023203533-76f2c92be8d5/go.mod h1:kHDnxA+SSNFeMEHz7xvhub1zvx4mOTRlWWRCay2n5NM=
+github.com/edwarnicke/govpp v0.0.0-20220311182453-f32f292e0e91 h1:iDVzIaYZjTg+hQGcDeOLJZc+5VfKvW7ye54EFX3CRQA=
+github.com/edwarnicke/govpp v0.0.0-20220311182453-f32f292e0e91/go.mod h1:kHDnxA+SSNFeMEHz7xvhub1zvx4mOTRlWWRCay2n5NM=
 github.com/edwarnicke/grpcfd v1.1.2 h1:2b8kCABQ1+JjSKGDoHadqSW7whCeTXMqtyo6jmB5B8k=
 github.com/edwarnicke/grpcfd v1.1.2/go.mod h1:rHihB9YvNMixz8rS+ZbwosI2kj65VLkeyYAI2M+/cGA=
 github.com/edwarnicke/serialize v0.0.0-20200705214914-ebc43080eecf/go.mod h1:XvbCO/QGsl3X8RzjBMoRpkm54FIAZH5ChK2j+aox7pw=

--- a/pkg/networkservice/chains/forwarder/server.go
+++ b/pkg/networkservice/chains/forwarder/server.go
@@ -99,8 +99,7 @@ func NewServer(ctx context.Context, name string, authzServer networkservice.Netw
 		mechanisms.NewServer(map[string]networkservice.NetworkServiceServer{
 			memif.MECHANISM: memif.NewServer(ctx, vppConn,
 				memif.WithDirectMemif(),
-				memif.WithChangeNetNS(),
-				memif.WithExternalVPP()),
+				memif.WithChangeNetNS()),
 			kernel.MECHANISM:    kernel.NewServer(vppConn),
 			vxlan.MECHANISM:     vxlan.NewServer(vppConn, tunnelIP, vxlan.WithVniPort(tunnelPort)),
 			wireguard.MECHANISM: wireguard.NewServer(vppConn, tunnelIP),
@@ -122,7 +121,6 @@ func NewServer(ctx context.Context, name string, authzServer networkservice.Netw
 					// mechanisms
 					memif.NewClient(vppConn,
 						memif.WithChangeNetNS(),
-						memif.WithExternalVPP(),
 					),
 					kernel.NewClient(vppConn),
 					vxlan.NewClient(vppConn, tunnelIP, vxlan.WithVniPort(tunnelPort)),

--- a/pkg/networkservice/mechanisms/memif/client.go
+++ b/pkg/networkservice/mechanisms/memif/client.go
@@ -1,6 +1,6 @@
-// Copyright (c) 2020-2021 Cisco and/or its affiliates.
+// Copyright (c) 2020-2022 Cisco and/or its affiliates.
 //
-// Copyright (c) 2021 Doc.ai and/or its affiliates.
+// Copyright (c) 2021-2022 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -40,7 +40,7 @@ import (
 )
 
 type memifClient struct {
-	vppConn     *vppConnection
+	vppConn     api.Connection
 	changeNetNs bool
 	nsInfo      NetNSInfo
 }
@@ -54,10 +54,7 @@ func NewClient(vppConn api.Connection, options ...Option) networkservice.Network
 
 	return chain.NewNetworkServiceClient(
 		&memifClient{
-			vppConn: &vppConnection{
-				isExternal: opts.isVPPExternal,
-				Connection: vppConn,
-			},
+			vppConn:     vppConn,
 			changeNetNs: opts.changeNetNS,
 			nsInfo:      newNetNSInfo(),
 		},

--- a/pkg/networkservice/mechanisms/memif/option.go
+++ b/pkg/networkservice/mechanisms/memif/option.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Doc.ai and/or its affiliates.
+// Copyright (c) 2021-2022 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -19,7 +19,6 @@ package memif
 type memifOptions struct {
 	directMemifEnabled bool
 	changeNetNS        bool
-	isVPPExternal      bool
 }
 
 // Option is an option for the connect server
@@ -36,12 +35,5 @@ func WithDirectMemif() Option {
 func WithChangeNetNS() Option {
 	return func(o *memifOptions) {
 		o.changeNetNS = true
-	}
-}
-
-// WithExternalVPP sets if VPP is located in different net NS to the application
-func WithExternalVPP() Option {
-	return func(o *memifOptions) {
-		o.isVPPExternal = true
 	}
 }

--- a/pkg/networkservice/mechanisms/memif/server.go
+++ b/pkg/networkservice/mechanisms/memif/server.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 Cisco and/or its affiliates.
+// Copyright (c) 2020-2022 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -38,7 +38,7 @@ import (
 )
 
 type memifServer struct {
-	vppConn     *vppConnection
+	vppConn     api.Connection
 	changeNetNS bool
 	nsInfo      NetNSInfo
 }
@@ -58,10 +58,7 @@ func NewServer(chainCtx context.Context, vppConn api.Connection, options ...Opti
 	return chain.NewNetworkServiceServer(
 		memifProxyServer,
 		&memifServer{
-			vppConn: &vppConnection{
-				isExternal: opts.isVPPExternal,
-				Connection: vppConn,
-			},
+			vppConn:     vppConn,
 			changeNetNS: opts.changeNetNS,
 			nsInfo:      newNetNSInfo(),
 		},


### PR DESCRIPTION
Issue: https://github.com/networkservicemesh/sdk-vpp/issues/508

The main difference is that `MemifSocketFilenameAddDelV2` API doesn't have `Namespace` now. Instead, we should act like this: `@netns:ns0@somename`

Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>