### PR TITLE
Add an option where we can change the stats socket

### DIFF
--- a/pkg/networkservice/stats/common.go
+++ b/pkg/networkservice/stats/common.go
@@ -1,4 +1,6 @@
-// Copyright (c) 2021 Doc.ai and/or its affiliates.
+// Copyright (c) 2021-2022 Doc.ai and/or its affiliates.
+//
+// Copyright (c) 2022 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -68,8 +70,11 @@ func retrieveMetrics(ctx context.Context, statsConn *core.StatsConnection, segme
 	}
 }
 
-func initFunc(chainCtx context.Context) (*core.StatsConnection, error) {
-	statsConn, err := core.ConnectStats(statsclient.NewStatsClient(adapter.DefaultStatsSocket))
+func initFunc(chainCtx context.Context, statsSocket string) (*core.StatsConnection, error) {
+	if statsSocket == "" {
+		statsSocket = adapter.DefaultStatsSocket
+	}
+	statsConn, err := core.ConnectStats(statsclient.NewStatsClient(statsSocket))
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/pkg/networkservice/stats/option.go
+++ b/pkg/networkservice/stats/option.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2022 Cisco and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stats
+
+type statsOptions struct {
+	socket string
+}
+
+// Option is an option pattern for stats server/client
+type Option func(o *statsOptions)
+
+// WithSocket sets stats socket name
+func WithSocket(socket string) Option {
+	return func(o *statsOptions) {
+		o.socket = socket
+	}
+}


### PR DESCRIPTION
Issue: https://github.com/networkservicemesh/integration-k8s-kind/issues/325

Needed for the case of external vpp.

Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>