### PR TITLE
Connecting a remote interface without creating a VLAN on top

### DIFF
--- a/pkg/networkservice/mechanisms/vlan/l2vtr/common.go
+++ b/pkg/networkservice/mechanisms/vlan/l2vtr/common.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Nordix Foundation.
+// Copyright (c) 2021-2022 Nordix Foundation.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -33,6 +33,9 @@ import (
 
 func enableVtr(ctx context.Context, conn *networkservice.Connection, vppConn api.Connection) error {
 	if mechanism := vlanmech.ToMechanism(conn.GetMechanism()); mechanism != nil {
+		if mechanism.GetVlanID() == 0 {
+			return nil
+		}
 		swIfIndex, ok := ifindex.Load(ctx, true)
 		if !ok {
 			return nil
@@ -58,6 +61,9 @@ func enableVtr(ctx context.Context, conn *networkservice.Connection, vppConn api
 
 func disableVtr(ctx context.Context, conn *networkservice.Connection, vppConn api.Connection) error {
 	if mechanism := vlanmech.ToMechanism(conn.GetMechanism()); mechanism != nil {
+		if mechanism.GetVlanID() == 0 {
+			return nil
+		}
 		swIfIndex, ok := ifindex.Load(ctx, true)
 		if !ok {
 			return nil


### PR DESCRIPTION
Fix issue: [cmd-nse-remote-vlan/18](https://github.com/networkservicemesh/cmd-nse-remote-vlan/issues/18)
Do not create vlan sub-interface when VLAN-ID is set to 0

Signed-off-by: Laszlo Kiraly <laszlo.kiraly@est.tech>