### PR TITLE
Fix for MTU change: get L3 mtu instead of linkMTU

### DIFF
--- a/pkg/networkservice/mechanisms/vlan/mtu/client.go
+++ b/pkg/networkservice/mechanisms/vlan/mtu/client.go
@@ -60,7 +60,7 @@ func (m *mtuClient) Request(ctx context.Context, request *networkservice.Network
 	if mechanism := vlan.ToMechanism(conn.GetMechanism()); mechanism != nil {
 		localMtu, loaded := m.mtu.Load(swIfIndex)
 		if !loaded {
-			localMtu, err = getMTU(ctx, m.vppConn, swIfIndex)
+			localMtu, err = getL3MTU(ctx, m.vppConn, swIfIndex)
 			if err != nil {
 				closeCtx, cancelClose := postponeCtxFunc()
 				defer cancelClose()

--- a/pkg/networkservice/mechanisms/vlan/mtu/common.go
+++ b/pkg/networkservice/mechanisms/vlan/mtu/common.go
@@ -28,7 +28,9 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/tools/log"
 )
 
-func getMTU(ctx context.Context, vppConn api.Connection, swIfIndex interface_types.InterfaceIndex) (uint32, error) {
+const l3MtuIndex = 0
+
+func getL3MTU(ctx context.Context, vppConn api.Connection, swIfIndex interface_types.InterfaceIndex) (uint32, error) {
 	now := time.Now()
 	dc, err := interfaces.NewServiceClient(vppConn).SwInterfaceDump(ctx, &interfaces.SwInterfaceDump{
 		SwIfIndex: swIfIndex,
@@ -47,5 +49,5 @@ func getMTU(ctx context.Context, vppConn api.Connection, swIfIndex interface_typ
 		WithField("details.LinkMtu", details.LinkMtu).
 		WithField("duration", time.Since(now)).
 		WithField("vppapi", "SwInterfaceDump").Debug("completed")
-	return uint32(details.LinkMtu), nil
+	return details.Mtu[l3MtuIndex], nil
 }


### PR DESCRIPTION
Issue: [networkservicemesh/cmd-forwarder#557](https://github.com/networkservicemesh/cmd-forwarder-vpp/issues/557)
Related PR: #554

The L3 MTU is set based on link L2 mtu and should not modified.

Signed-off-by: Laszlo Kiraly <laszlo.kiraly@est.tech>