### PR TITLE
Add cmd-nsc-simple-docker to dependent repositories

### DIFF
--- a/.github/workflows/update-dependent-repositories-gomod.yaml
+++ b/.github/workflows/update-dependent-repositories-gomod.yaml
@@ -20,6 +20,7 @@ jobs:
         "cmd-nse-icmp-responder-vpp",
         "cmd-nse-vlan-vpp",
         "cmd-nse-firewall-vpp",
-        "cmd-nse-vl3-vpp"]
+        "cmd-nse-vl3-vpp",
+        "cmd-nsc-simple-docker"]
     secrets:
       token: ${{ secrets.NSM_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Issue: https://github.com/networkservicemesh/cmd-nsc-simple-docker/issues/1

Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>