### PR TITLE
Merge vpphelper with a fix for log timestamps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	git.fd.io/govpp.git v0.3.6-0.20210927044411-385ccc0d8ba9
 	github.com/cilium/ebpf v0.10.0
+	github.com/edwarnicke/exechelper v1.0.2
 	github.com/edwarnicke/govpp v0.0.0-20230130211138-14ef5d20b1d0
 	github.com/edwarnicke/serialize v1.0.7
 	github.com/golang/protobuf v1.5.2
@@ -14,6 +15,7 @@ require (
 	github.com/networkservicemesh/sdk v0.5.1-0.20230501005204-6fa2f68d5532
 	github.com/networkservicemesh/sdk-kernel v0.0.0-20230501005646-bfd86b518964
 	github.com/pkg/errors v0.9.1
+	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.0
 	github.com/thanhpk/randstr v1.0.4
 	github.com/vishvananda/netlink v1.2.1-beta.2.0.20220630165224-c591ada0fb2b
@@ -23,6 +25,7 @@ require (
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20200609130330-bd2cb7843e1b
 	google.golang.org/grpc v1.49.0
 	google.golang.org/protobuf v1.28.1
+	gopkg.in/fsnotify.v1 v1.4.7
 )
 
 require (
@@ -31,7 +34,6 @@ require (
 	github.com/antonfisher/nested-logrus-formatter v1.3.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/edwarnicke/exechelper v1.0.2 // indirect
 	github.com/edwarnicke/genericsync v0.0.0-20220910010113-61a344f9bc29 // indirect
 	github.com/edwarnicke/grpcfd v1.1.2 // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
@@ -49,7 +51,6 @@ require (
 	github.com/open-policy-agent/opa v0.44.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
-	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.0.0 // indirect
 	github.com/tchap/go-patricia/v2 v2.3.1 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect

--- a/go.sum
+++ b/go.sum
@@ -600,6 +600,7 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
+gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/square/go-jose.v2 v2.4.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/square/go-jose.v2 v2.5.1 h1:7odma5RETjNHWJnR32wx8t+Io4djHE1PqxCFx3iiZ2w=

--- a/pkg/tools/vppconnection/connection.go
+++ b/pkg/tools/vppconnection/connection.go
@@ -1,0 +1,152 @@
+// Copyright (c) 2020 Cisco and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vppconnection
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"time"
+
+	"git.fd.io/govpp.git"
+	"git.fd.io/govpp.git/api"
+	"git.fd.io/govpp.git/core"
+	"github.com/networkservicemesh/sdk/pkg/tools/log"
+	"github.com/pkg/errors"
+	"gopkg.in/fsnotify.v1"
+)
+
+type connection struct {
+	*core.Connection
+	ready chan struct{}
+	err   error
+}
+
+// DialContext - Dials vpp and returns a Connection
+// DialContext is 'lazy' meaning that if there is no socket yet at filename, we will continue to try
+// until there is one or the ctx is canceled.
+func DialContext(ctx context.Context, filename string) Connection {
+	c := &connection{
+		ready: make(chan struct{}),
+	}
+	go c.connect(ctx, filename)
+	return c
+}
+
+func (c *connection) connect(ctx context.Context, filename string) {
+	defer close(c.ready)
+	now := time.Now()
+	c.err = waitForSocket(ctx, filename)
+	if c.err != nil {
+		log.FromContext(ctx).Debugf("%s was not created after %s due to %+v", filename, time.Since(now), c.err)
+		return
+	}
+	log.FromContext(ctx).Debugf("%s was created after %s", filename, time.Since(now))
+	now = time.Now()
+	attempts := 1
+	for {
+		select {
+		case <-ctx.Done():
+			c.err = errors.WithStack(ctx.Err())
+			log.FromContext(ctx).Debugf("unable to connect to %s after %s due to %+v", filename, time.Since(now), c.err)
+			return
+		default:
+			c.Connection, c.err = govpp.Connect(filename)
+			if c.err == nil {
+				log.FromContext(ctx).Debugf("successfully connected to %s after %s and %d attempts", filename, time.Since(now), attempts)
+				return
+			}
+			attempts++
+			<-time.After(time.Millisecond)
+		}
+	}
+}
+
+func (c *connection) NewStream(ctx context.Context, options ...api.StreamOption) (api.Stream, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-c.ready:
+		if c.err != nil {
+			return nil, c.err
+		}
+	}
+	return c.Connection.NewStream(ctx, options...)
+}
+
+func (c *connection) Invoke(ctx context.Context, req, reply api.Message) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-c.ready:
+		if c.err != nil {
+			return c.err
+		}
+	}
+	return c.Connection.Invoke(ctx, req, reply)
+}
+
+func (c *connection) NewAPIChannel() (api.Channel, error) {
+	<-c.ready
+	if c.err != nil {
+		return nil, c.err
+	}
+	return c.Connection.NewAPIChannel()
+}
+
+func (c *connection) NewAPIChannelBuffered(reqChanBufSize, replyChanBufSize int) (api.Channel, error) {
+	<-c.ready
+	if c.err != nil {
+		return nil, c.err
+	}
+	return c.Connection.NewAPIChannelBuffered(reqChanBufSize, replyChanBufSize)
+}
+
+var _ Connection = &connection{}
+
+func waitForSocket(ctx context.Context, filename string) error {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer func() { _ = watcher.Close() }()
+	if err = watcher.Add(filepath.Dir(filename)); err != nil {
+		return errors.WithStack(err)
+	}
+
+	_, err = os.Stat(filename)
+	if os.IsNotExist(err) {
+		for {
+			select {
+			// watch for events
+			case event := <-watcher.Events:
+				if event.Name == filename && event.Op == fsnotify.Create {
+					return nil
+				}
+				// watch for errors
+			case err = <-watcher.Errors:
+				return errors.WithStack(err)
+			case <-ctx.Done():
+				return errors.WithStack(ctx.Err())
+			}
+		}
+	}
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
+}

--- a/pkg/tools/vppconnection/connection.go
+++ b/pkg/tools/vppconnection/connection.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Cisco and/or its affiliates.
+// Copyright (c) 2020-2023 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/tools/vppconnection/doc.go
+++ b/pkg/tools/vppconnection/doc.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2020 Cisco and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package vppconnection provides a simple Start function that will start up a local vpp,
+// dial it, and return the grpc.ClientConnInterface
+package vppconnection

--- a/pkg/tools/vppconnection/doc.go
+++ b/pkg/tools/vppconnection/doc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Cisco and/or its affiliates.
+// Copyright (c) 2020-2023 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/tools/vppconnection/options.go
+++ b/pkg/tools/vppconnection/options.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2020 Cisco and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vppconnection
+
+const (
+	// DefaultRootDir - Default value for RootDir
+	DefaultRootDir = ""
+)
+
+type option struct {
+	rootDir   string
+	vppConfig string
+}
+
+// Option - Option for use with vppagent.Start(...)
+type Option func(opt *option)
+
+// WithRootDir - set a root dir (usually a tmpDir) for all conf files.
+func WithRootDir(rootDir string) Option {
+	return func(opt *option) {
+		opt.rootDir = rootDir
+	}
+}
+
+// WithVppConfig - vpp.conf template
+// %[1]s will be replaced in the template with the value of the rootDir
+func WithVppConfig(vppConfig string) Option {
+	return func(opt *option) {
+		opt.vppConfig = vppConfig
+	}
+}

--- a/pkg/tools/vppconnection/options.go
+++ b/pkg/tools/vppconnection/options.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Cisco and/or its affiliates.
+// Copyright (c) 2020-2023 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/tools/vppconnection/start.go
+++ b/pkg/tools/vppconnection/start.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2020 Cisco and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vppconnection
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+
+	"git.fd.io/govpp.git/api"
+	"github.com/edwarnicke/exechelper"
+	"github.com/networkservicemesh/sdk/pkg/tools/log"
+	"github.com/sirupsen/logrus"
+)
+
+// Connection Combination of api.Connection and api.ChannelProvider
+type Connection interface {
+	api.Connection
+	api.ChannelProvider
+}
+
+// StartAndDialContext - starts vpp
+// Stdout and Stderr for vpp are set to be logrus.Entry.Writer().
+func StartAndDialContext(ctx context.Context, opts ...Option) (conn Connection, errCh <-chan error) {
+	o := &option{
+		rootDir:   DefaultRootDir,
+		vppConfig: vppConfContents,
+	}
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	if err := writeDefaultConfigFiles(ctx, o); err != nil {
+		errCh := make(chan error, 1)
+		errCh <- err
+		close(errCh)
+		return nil, errCh
+	}
+	logWriter := logrus.StandardLogger().WithField("cmd", "vpp").Writer()
+	vppErrCh := exechelper.Start("vpp -c "+filepath.Join(o.rootDir, vppConfFilename),
+		exechelper.WithContext(ctx),
+		exechelper.WithStdout(logWriter),
+		exechelper.WithStderr(logWriter),
+	)
+	select {
+	case err := <-vppErrCh:
+		errCh := make(chan error, 1)
+		errCh <- err
+		close(errCh)
+		return nil, errCh
+	default:
+	}
+
+	return DialContext(ctx, filepath.Join(o.rootDir, "/var/run/vpp/api.sock")), vppErrCh
+}
+
+func writeDefaultConfigFiles(ctx context.Context, o *option) error {
+	configFiles := map[string]string{
+		vppConfFilename: fmt.Sprintf(o.vppConfig, o.rootDir),
+	}
+	for filename, contents := range configFiles {
+		filename = filepath.Join(o.rootDir, filename)
+		if _, err := os.Stat(filename); os.IsNotExist(err) {
+			log.FromContext(ctx).Infof("Configuration file: %q not found, using defaults", filename)
+			if err := os.MkdirAll(path.Dir(filename), 0700); err != nil {
+				return err
+			}
+			if err := ioutil.WriteFile(filename, []byte(contents), 0600); err != nil {
+				return err
+			}
+		}
+	}
+	if err := os.MkdirAll(filepath.Join(o.rootDir, "/var/run/vpp"), 0700); os.IsNotExist(err) {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Join(o.rootDir, "/var/log/vpp"), 0700); os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}

--- a/pkg/tools/vppconnection/start.go
+++ b/pkg/tools/vppconnection/start.go
@@ -79,18 +79,18 @@ func writeDefaultConfigFiles(ctx context.Context, o *option) error {
 		filename = filepath.Join(o.rootDir, filename)
 		if _, err := os.Stat(filename); os.IsNotExist(err) {
 			log.FromContext(ctx).Infof("Configuration file: %q not found, using defaults", filename)
-			if err := os.MkdirAll(path.Dir(filename), 0700); err != nil {
+			if err := os.MkdirAll(path.Dir(filename), 0o700); err != nil {
 				return err
 			}
-			if err := ioutil.WriteFile(filename, []byte(contents), 0600); err != nil {
+			if err := ioutil.WriteFile(filename, []byte(contents), 0o600); err != nil {
 				return err
 			}
 		}
 	}
-	if err := os.MkdirAll(filepath.Join(o.rootDir, "/var/run/vpp"), 0700); os.IsNotExist(err) {
+	if err := os.MkdirAll(filepath.Join(o.rootDir, "/var/run/vpp"), 0o700); os.IsNotExist(err) {
 		return err
 	}
-	if err := os.MkdirAll(filepath.Join(o.rootDir, "/var/log/vpp"), 0700); os.IsNotExist(err) {
+	if err := os.MkdirAll(filepath.Join(o.rootDir, "/var/log/vpp"), 0o700); os.IsNotExist(err) {
 		return err
 	}
 	return nil

--- a/pkg/tools/vppconnection/start.go
+++ b/pkg/tools/vppconnection/start.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Cisco and/or its affiliates.
+// Copyright (c) 2020-2023 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/tools/vppconnection/vpp.conf.go
+++ b/pkg/tools/vppconnection/vpp.conf.go
@@ -1,0 +1,193 @@
+// Copyright (c) 2020 Cisco and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vppconnection
+
+const (
+	vppConfFilename = "/etc/vpp/helper/vpp.conf"
+	vppConfContents = `unix {
+  nodaemon
+  log %[1]s/var/log/vpp/vpp.log
+  full-coredump
+  cli-listen %[1]s/var/run/vpp/cli.sock
+  gid vpp
+}
+
+buffers {
+	# buffers-per-numa was chosen as 256 buffers/interface * 128 possible interfaces
+	buffers-per-numa 32768
+	# data-size was chosen using 4096 page - 256 bytes metadata - one cache line (64 bytes) to just *barely* fit in
+	# one page, since we can't split a buffer across a page.
+	default data-size 3776
+}
+
+## logging {
+##   default-syslog-log-level debug
+## }
+
+api-trace {
+## This stanza controls binary API tracing. Unless there is a very strong reason,
+## please leave this feature enabled.
+  on
+## Additional parameters:
+##
+## To set the number of binary API trace records in the circular buffer, configure nitems
+##
+## nitems <nnn>
+##
+## To save the api message table decode tables, configure a filename. Results in /tmp/<filename>
+## Very handy for understanding api message changes between versions, identifying missing
+## plugins, and so forth.
+##
+## save-api-table <filename>
+}
+
+api-segment {
+  gid vpp
+}
+
+socksvr {
+  socket-name %[1]s/var/run/vpp/api.sock
+}
+
+statseg {
+  socket-name %[1]s/var/run/vpp/stats.sock
+}
+
+cpu {
+	## In the VPP there is one main thread and optionally the user can create worker(s)
+	## The main thread and worker thread(s) can be pinned to CPU core(s) manually or automatically
+
+	## Manual pinning of thread(s) to CPU core(s)
+
+	## Set logical CPU core where main thread runs, if main core is not set
+	## VPP will use core 1 if available
+	# main-core 1
+
+	## Set logical CPU core(s) where worker threads are running
+	# corelist-workers 2-3,18-19
+
+	## Automatic pinning of thread(s) to CPU core(s)
+
+	## Sets number of CPU core(s) to be skipped (1 ... N-1)
+	## Skipped CPU core(s) are not used for pinning main thread and working thread(s).
+	## The main thread is automatically pinned to the first available CPU core and worker(s)
+	## are pinned to next free CPU core(s) after core assigned to main thread
+	# skip-cores 4
+
+	## Specify a number of workers to be created
+	## Workers are pinned to N consecutive CPU cores while skipping "skip-cores" CPU core(s)
+	## and main thread's CPU core
+	# workers 2
+
+	## Set scheduling policy and priority of main and worker threads
+
+	## Scheduling policy options are: other (SCHED_OTHER), batch (SCHED_BATCH)
+	## idle (SCHED_IDLE), fifo (SCHED_FIFO), rr (SCHED_RR)
+	# scheduler-policy fifo
+
+	## Scheduling priority is used only for "real-time policies (fifo and rr),
+	## and has to be in the range of priorities supported for a particular policy
+	# scheduler-priority 50
+}
+
+# dpdk {
+	## Change default settings for all intefaces
+	# dev default {
+		## Number of receive queues, enables RSS
+		## Default is 1
+		# num-rx-queues 3
+
+		## Number of transmit queues, Default is equal
+		## to number of worker threads or 1 if no workers treads
+		# num-tx-queues 3
+
+		## Number of descriptors in transmit and receive rings
+		## increasing or reducing number can impact performance
+		## Default is 1024 for both rx and tx
+		# num-rx-desc 512
+		# num-tx-desc 512
+
+		## VLAN strip offload mode for interface
+		## Default is off
+		# vlan-strip-offload on
+	# }
+
+	## Whitelist specific interface by specifying PCI address
+	# dev 0000:02:00.0
+
+	## Whitelist specific interface by specifying PCI address and in
+	## addition specify custom parameters for this interface
+	# dev 0000:02:00.1 {
+	#	num-rx-queues 2
+	# }
+
+	## Specify bonded interface and its slaves via PCI addresses
+	##
+	## Bonded interface in XOR load balance mode (mode 2) with L3 and L4 headers
+	# vdev eth_bond0,mode=2,slave=0000:02:00.0,slave=0000:03:00.0,xmit_policy=l34
+	# vdev eth_bond1,mode=2,slave=0000:02:00.1,slave=0000:03:00.1,xmit_policy=l34
+	##
+	## Bonded interface in Active-Back up mode (mode 1)
+	# vdev eth_bond0,mode=1,slave=0000:02:00.0,slave=0000:03:00.0
+	# vdev eth_bond1,mode=1,slave=0000:02:00.1,slave=0000:03:00.1
+
+	## Change UIO driver used by VPP, Options are: igb_uio, vfio-pci,
+	## uio_pci_generic or auto (default)
+	# uio-driver vfio-pci
+
+	## Disable mutli-segment buffers, improves performance but
+	## disables Jumbo MTU support
+	# no-multi-seg
+
+	## Increase number of buffers allocated, needed only in scenarios with
+	## large number of interfaces and worker threads. Value is per CPU socket.
+	## Default is 16384
+	# num-mbufs 128000
+
+	## Change hugepages allocation per-socket, needed only if there is need for
+	## larger number of mbufs. Default is 256M on each detected CPU socket
+	# socket-mem 2048,2048
+
+	## Disables UDP / TCP TX checksum offload. Typically needed for use
+	## faster vector PMDs (together with no-multi-seg)
+	# no-tx-checksum-offload
+# }
+
+
+# plugins {
+	## Adjusting the plugin path depending on where the VPP plugins are
+	#	path /home/bms/vpp/build-root/install-vpp-native/vpp/lib64/vpp_plugins
+
+	## Disable all plugins by default and then selectively enable specific plugins
+	# plugin default { disable }
+	# plugin dpdk_plugin.so { enable }
+	# plugin acl_plugin.so { enable }
+
+	## Enable all plugins by default and then selectively disable specific plugins
+	# plugin dpdk_plugin.so { disable }
+	# plugin acl_plugin.so { disable }
+# }
+
+	## Alternate syntax to choose plugin path
+	# plugin_path /home/bms/vpp/build-root/install-vpp-native/vpp/lib64/vpp_plugins
+
+# NSM specific changes below this line
+plugins {
+	plugin dpdk_plugin.so { disable }
+}
+`
+)

--- a/pkg/tools/vppconnection/vpp.conf.go
+++ b/pkg/tools/vppconnection/vpp.conf.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Cisco and/or its affiliates.
+// Copyright (c) 2020-2023 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //


### PR DESCRIPTION
Required for https://github.com/networkservicemesh/deployments-k8s/issues/9124

This PR copies files from https://github.com/edwarnicke/vpphelper, modified to fix log timestamps in vpp output.

I patched forwarder-vpp to use this change and made sure that it prints log timestamps as expected.