### PR TITLE
Revert "Add pinggrouprange to forwarder's chain (#718)"

### DIFF
--- a/pkg/networkservice/chains/forwarder/server.go
+++ b/pkg/networkservice/chains/forwarder/server.go
@@ -56,7 +56,6 @@ import (
 
 	"github.com/networkservicemesh/sdk-kernel/pkg/kernel/networkservice/connectioncontextkernel"
 	"github.com/networkservicemesh/sdk-kernel/pkg/kernel/networkservice/ethernetcontext"
-	"github.com/networkservicemesh/sdk-kernel/pkg/kernel/networkservice/pinggrouprange"
 
 	"github.com/networkservicemesh/sdk-vpp/pkg/networkservice/afxdppinhole"
 	"github.com/networkservicemesh/sdk-vpp/pkg/networkservice/connectioncontext/mtu"
@@ -123,7 +122,6 @@ func NewServer(ctx context.Context, tokenGenerator token.GeneratorFunc, vppConn 
 		l2bridgedomain.NewServer(vppConn),
 		connectioncontextkernel.NewServer(),
 		ethernetcontext.NewVFServer(),
-		pinggrouprange.NewServer(),
 		tag.NewServer(ctx, vppConn),
 		mtu.NewServer(vppConn),
 		mechanisms.NewServer(map[string]networkservice.NetworkServiceServer{
@@ -148,7 +146,6 @@ func NewServer(ctx context.Context, tokenGenerator token.GeneratorFunc, vppConn 
 						cleanup.NewClient(ctx, opts.cleanupOpts...),
 						mechanismtranslation.NewClient(),
 						connectioncontextkernel.NewClient(),
-						pinggrouprange.NewClient(),
 						stats.NewClient(ctx, opts.statsOpts...),
 						up.NewClient(ctx, vppConn),
 						mtu.NewClient(vppConn),


### PR DESCRIPTION
This reverts commit ce2e514e2a71b25b450d83af3c7209e396b77122.

Moved to `sdk-kernel/connectioncontext` - https://github.com/networkservicemesh/sdk-kernel/pull/601