### PR TITLE
Use a copy of ACLRules instead of the original

### DIFF
--- a/pkg/networkservice/acl/common.go
+++ b/pkg/networkservice/acl/common.go
@@ -90,11 +90,14 @@ func addACLToACLList(ctx context.Context, vppConn api.Connection, tag string, eg
 }
 
 func aclAdd(tag string, egress bool, aRules []acl_types.ACLRule) *acl.ACLAddReplace {
+	aRulesCopy := make([]acl_types.ACLRule, len(aRules))
+	copy(aRulesCopy, aRules)
+
 	aclAddReplace := &acl.ACLAddReplace{
 		ACLIndex: ^uint32(0),
 		Tag:      tag,
-		Count:    uint32(len(aRules)),
-		R:        aRules,
+		Count:    uint32(len(aRulesCopy)),
+		R:        aRulesCopy,
 	}
 	if egress {
 		for i := range aclAddReplace.R {

--- a/pkg/networkservice/acl/server.go
+++ b/pkg/networkservice/acl/server.go
@@ -21,6 +21,7 @@ package acl
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/edwarnicke/genericsync"
 	"github.com/golang/protobuf/ptypes/empty"
@@ -61,7 +62,7 @@ func (a *aclServer) Request(ctx context.Context, request *networkservice.Network
 	_, loaded := a.aclIndices.Load(conn.GetId())
 	if !loaded && len(a.aclRules) > 0 {
 		var indices []uint32
-		if indices, err = create(ctx, a.vppConn, aclTag, metadata.IsClient(a), a.aclRules); err != nil {
+		if indices, err = create(ctx, a.vppConn, fmt.Sprintf("%s-%s", aclTag, conn.GetId()), metadata.IsClient(a), a.aclRules); err != nil {
 			closeCtx, cancelClose := postponeCtxFunc()
 			defer cancelClose()
 


### PR DESCRIPTION
### Description
In the process of applying new rules, we may accidentally change the original ones

Issue: https://github.com/networkservicemesh/deployments-k8s/issues/10319