### PR TITLE
Fix veth-pair creation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/networkservicemesh/sdk-kernel v0.0.0-20240405103539-cf3b1676a8b2
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.4
-	github.com/thanhpk/randstr v1.0.4
 	github.com/vishvananda/netlink v1.2.1-beta.2.0.20220630165224-c591ada0fb2b
 	github.com/vishvananda/netns v0.0.0-20211101163701-50045581ed74
 	go.fd.io/govpp v0.10.0-alpha.0.20240110141843-761adec77524

--- a/go.sum
+++ b/go.sum
@@ -155,8 +155,6 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/tchap/go-patricia/v2 v2.3.1 h1:6rQp39lgIYZ+MHmdEq4xzuk1t7OdC35z/xm0BGhTkes=
 github.com/tchap/go-patricia/v2 v2.3.1/go.mod h1:VZRHKAb53DLaG+nA9EaYYiaEx6YztwDlLElMsnSHD4k=
-github.com/thanhpk/randstr v1.0.4 h1:IN78qu/bR+My+gHCvMEXhR/i5oriVHcTB/BJJIRTsNo=
-github.com/thanhpk/randstr v1.0.4/go.mod h1:M/H2P1eNLZzlDwAzpkkkUvoyNNMbzRGhESZuEQk3r0U=
 github.com/vishvananda/netlink v1.2.1-beta.2.0.20220630165224-c591ada0fb2b h1:CyMWBGvc1ZOvUBxW51DVTSIIAeJWWJJs+Ko3ouM/AVI=
 github.com/vishvananda/netlink v1.2.1-beta.2.0.20220630165224-c591ada0fb2b/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=

--- a/pkg/tools/mechutils/mechutils.go
+++ b/pkg/tools/mechutils/mechutils.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2021-2022 Nordix Foundation.
 //
-// Copyright (c) 2020-2023 Cisco and/or its affiliates.
+// Copyright (c) 2020-2024 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -50,15 +50,13 @@ func ToNSFilename(mechanism *kernel.Mechanism) (string, error) {
 //
 //	Note: Don't use this in a non-forwarder context
 func ToAlias(conn *networkservice.Connection, isClient bool) string {
-	// Naming is tricky.  We want to name based on either the next or prev connection id depending on whether we
-	// are on the client or server side.  Since this chain element is designed for use in a Forwarder,
-	// if we are on the client side, we want to name based on the connection id from the NSE that is Next
-	// if we are not the client, we want to name for the connection of of the client addressing us, which is Prev
+	// Naming is tricky. For the same connection, the aliases must always be the same.
+	// For consistency when using healing when there are multiple restarts, we can only rely on the first PathSegment.
 	namingConn := conn.Clone()
-	namingConn.Id = namingConn.GetPrevPathSegment().GetId()
+	namingConn.Id = namingConn.GetPath().GetPathSegments()[0].GetId()
 	alias := fmt.Sprintf("server-%s", namingConn.GetId())
 	if isClient {
-		namingConn.Id = namingConn.GetNextPathSegment().GetId()
+		namingConn.Id = namingConn.GetPath().GetPathSegments()[0].GetId()
 		alias = fmt.Sprintf("client-%s", namingConn.GetId())
 	}
 	return alias


### PR DESCRIPTION
### Description
Due to dynamic name generation on the endpoint side, we can no longer rely on `mechanism.GetInterfaceName()` to remove the previous interface during healing.

Issue: https://github.com/networkservicemesh/integration-k8s-gke/issues/435