### PR TITLE
Remove netNsMonitor from forwarder-vpp

### DIFF
--- a/pkg/networkservice/chains/forwarder/server.go
+++ b/pkg/networkservice/chains/forwarder/server.go
@@ -69,7 +69,6 @@ import (
 	"github.com/networkservicemesh/sdk-vpp/pkg/networkservice/mechanisms/vxlan"
 	"github.com/networkservicemesh/sdk-vpp/pkg/networkservice/mechanisms/wireguard"
 	"github.com/networkservicemesh/sdk-vpp/pkg/networkservice/metrics"
-	"github.com/networkservicemesh/sdk-vpp/pkg/networkservice/nsmonitor"
 	"github.com/networkservicemesh/sdk-vpp/pkg/networkservice/pinhole"
 	"github.com/networkservicemesh/sdk-vpp/pkg/networkservice/tag"
 	"github.com/networkservicemesh/sdk-vpp/pkg/networkservice/up"
@@ -167,7 +166,6 @@ func NewServer(ctx context.Context, tokenGenerator token.GeneratorFunc, vppConn 
 						afxdppinhole.NewClient(),
 						pinhole.NewClient(vppConn, pinhole.WithSharedMutex(pinholeMutex)),
 						recvfd.NewClient(),
-						nsmonitor.NewClient(ctx),
 						sendfd.NewClient(),
 					},
 						opts.clientAdditionalFunctionality...,


### PR DESCRIPTION
## Description
netNsMonitor has some bugs that make it randomly close healthy connections. So we decided to delete it and check if it affects NSM.