### PR TITLE
Add logs to waitForPeerUp function to see what `wireguard` events we get

### DIFF
--- a/pkg/networkservice/up/peerup/common.go
+++ b/pkg/networkservice/up/peerup/common.go
@@ -86,8 +86,10 @@ func waitForPeerUp(ctx context.Context, vppConn api.Connection, pubKey string, i
 	for {
 		select {
 		case <-ctx.Done():
+			log.FromContext(ctx).Infof("failed to get any WireguardPeerEvents: %s", ctx.Err())
 			return errors.Wrap(ctx.Err(), "provided context is done")
 		case rawMsg := <-watcher.Events():
+			log.FromContext(ctx).Infof("got WireguardPeerEvent: %v, %v", rawMsg.GetMessageName(), rawMsg.GetMessageType())
 			if msg, ok := rawMsg.(*wireguard.WireguardPeerEvent); ok &&
 				msg.PeerIndex == peerIndex &&
 				msg.Flags&wireguard.WIREGUARD_PEER_ESTABLISHED != 0 {


### PR DESCRIPTION
## Issue
https://github.com/networkservicemesh/integration-k8s-kind/actions/runs/10469610159/job/28993020446?pr=1030#step:9:3846