### PR TITLE
Introduce optional prefix for Prometheus metric names

### DIFF
--- a/pkg/networkservice/metrics/stats/prometheus.go
+++ b/pkg/networkservice/metrics/stats/prometheus.go
@@ -17,6 +17,7 @@
 package stats
 
 import (
+	"os"
 	"sync"
 
 	prom "github.com/networkservicemesh/sdk/pkg/tools/prometheus"
@@ -30,76 +31,141 @@ var (
 	ClientRxBytes = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "client_rx_bytes_total",
-			Help: "Total received bytes by client",
+			Help: "Total number of received bytes by the local NetworkServiceClient vpp interface.",
 		},
 	)
 	// ClientTxBytes - Total transmitted bytes by client
 	ClientTxBytes = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "client_tx_bytes_total",
-			Help: "Total transmitted bytes by client",
+			Help: "Total number of transmitted bytes by the local NetworkServiceClient vpp interface.",
 		},
 	)
 	// ClientRxPackets - Total received packets by client
 	ClientRxPackets = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "client_rx_packets_total",
-			Help: "Total received packets by client",
+			Help: "Total number of received packets by the local NetworkServiceClient vpp interface.",
 		},
 	)
 	// ClientTxPackets - Total transmitted packets by client
 	ClientTxPackets = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "client_tx_packets_total",
-			Help: "Total transmitted packets by client",
+			Help: "Total number of transmitted packets by the local NetworkServiceClient vpp interface.",
 		},
 	)
 	// ClientDrops - Total drops by client
 	ClientDrops = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "client_drops_total",
-			Help: "Total drops by client",
+			Help: "Total number of dropped packets by the local NetworkServiceClient vpp interface.",
 		},
 	)
 	// ServerRxBytes - Total received bytes by server
 	ServerRxBytes = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "server_rx_bytes_total",
-			Help: "Total received bytes by server",
+			Help: "Total number of received bytes by the local NetworkServiceServer vpp interface.",
 		},
 	)
 	// ServerTxBytes - Total transmitted bytes by server
 	ServerTxBytes = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "server_tx_bytes_total",
-			Help: "Total transmitted bytes by server",
+			Help: "Total number of transmitted bytes by the local NetworkServiceServer vpp interface.",
 		},
 	)
 	// ServerRxPackets - Total received packets by server
 	ServerRxPackets = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "server_rx_packets_total",
-			Help: "Total received packets by server",
+			Help: "Total number of received packets by the local NetworkServiceServer vpp interface.",
 		},
 	)
 	// ServerTxPackets - Total transmitted packets by server
 	ServerTxPackets = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "server_tx_packets_total",
-			Help: "Total transmitted packets by server",
+			Help: "Total number of transmitted packets by the local NetworkServiceServer vpp interface.",
 		},
 	)
 	// ServerDrops - Total drops by server
 	ServerDrops = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "server_drops_total",
-			Help: "Total drops by server",
+			Help: "Total number of dropped packets by the local NetworkServiceServer vpp interface.",
 		},
 	)
 )
 
 func registerMetrics() {
 	if prom.IsEnabled() {
+		prometheusMetricPrefixEnv := "PROMETHEUS_METRIC_PREFIX"
+		prefix := os.Getenv(prometheusMetricPrefixEnv)
+		if prefix != "" {
+			ClientRxBytes = prometheus.NewGauge(
+				prometheus.GaugeOpts{
+					Name: prefix + "client_rx_bytes_total",
+					Help: "Total number of received bytes by the local NetworkServiceClient vpp interface.",
+				},
+			)
+			ClientTxBytes = prometheus.NewGauge(
+				prometheus.GaugeOpts{
+					Name: prefix + "client_tx_bytes_total",
+					Help: "Total number of transmitted bytes by the local NetworkServiceClient vpp interface.",
+				},
+			)
+			ClientRxPackets = prometheus.NewGauge(
+				prometheus.GaugeOpts{
+					Name: prefix + "client_rx_packets_total",
+					Help: "Total number of received packets by the local NetworkServiceClient vpp interface.",
+				},
+			)
+			ClientTxPackets = prometheus.NewGauge(
+				prometheus.GaugeOpts{
+					Name: prefix + "client_tx_packets_total",
+					Help: "Total number of transmitted packets by the local NetworkServiceClient vpp interface.",
+				},
+			)
+			ClientDrops = prometheus.NewGauge(
+				prometheus.GaugeOpts{
+					Name: prefix + "client_drops_total",
+					Help: "Total number of dropped packets by the local NetworkServiceClient vpp interface.",
+				},
+			)
+			ServerRxBytes = prometheus.NewGauge(
+				prometheus.GaugeOpts{
+					Name: prefix + "server_rx_bytes_total",
+					Help: "Total number of received bytes by the local NetworkServiceServer vpp interface.",
+				},
+			)
+			ServerTxBytes = prometheus.NewGauge(
+				prometheus.GaugeOpts{
+					Name: prefix + "server_tx_bytes_total",
+					Help: "Total number of transmitted bytes by the local NetworkServiceServer vpp interface.",
+				},
+			)
+			ServerRxPackets = prometheus.NewGauge(
+				prometheus.GaugeOpts{
+					Name: prefix + "server_rx_packets_total",
+					Help: "Total number of received packets by the local NetworkServiceServer vpp interface.",
+				},
+			)
+			ServerTxPackets = prometheus.NewGauge(
+				prometheus.GaugeOpts{
+					Name: prefix + "server_tx_packets_total",
+					Help: "Total number of transmitted packets by the local NetworkServiceServer vpp interface.",
+				},
+			)
+			ServerDrops = prometheus.NewGauge(
+				prometheus.GaugeOpts{
+					Name: prefix + "server_drops_total",
+					Help: "Total number of dropped packets by the local NetworkServiceServer vpp interface.",
+				},
+			)
+		}
+
 		prometheus.MustRegister(ClientRxBytes)
 		prometheus.MustRegister(ClientTxBytes)
 		prometheus.MustRegister(ClientRxPackets)


### PR DESCRIPTION
## Description

This PR introduces an optional way to add a specified prefix to the Prometheus metric names of the `forwarder-vpp`. This functionality can be enabled by defining the `PROMETHEUS_METRIC_PREFIX` environment variable with the desired prefix string in the config file of the `forwarder-vpp`.

## Issue link

https://github.com/networkservicemesh/sdk-vpp/issues/898